### PR TITLE
BIN-9 gradle에 build 전용 test 추가 및 build 시 실행되는 Test task 변경

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -56,7 +56,14 @@ tasks.processResources {
 
 tasks.withType<Test> {
     useJUnitPlatform()
+}
+
+tasks.register("buildTest", Test::class) {
     exclude("com/anyject/learning/**")
+}
+
+tasks.named("build") {
+    dependsOn("buildTest")
 }
 
 tasks.processResources {


### PR DESCRIPTION
## Summary

gradle에 build 전용 테스트 추가 및 build 시 실행되는 테스트 태스크 변경

## Describe your changes

build.gradle.kts에 build 시에 실행될 buildTest task 추가
build task가 의존하는 task  변경

## Issue number and link
BIN-9